### PR TITLE
test(sidekiq): fix sidekiq test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,4 +63,11 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Use inline job adapter for tests to avoid Redis dependency
+  config.active_job.queue_adapter = :test
+
+  # Configure Sidekiq to use fake mode for tests (no Redis required)
+  require 'sidekiq/testing'
+  Sidekiq::Testing.fake!
 end


### PR DESCRIPTION
# Problem

**What was the problem?**
* RSpec tests were failing with `RedisClient::CannotConnectError: Connection refused - connect(2) for 127.0.0.1:6379` when running Sidekiq job tests
* Tests were trying to connect to Redis but Redis wasn't running on the local development machine
* This prevented developers from running the full test suite locally without setting up Redis infrastructure

**What bug does it fix?**
* Fixes failing tests in `MarkCartAsAbandonedJob` and related Sidekiq job tests
* Resolves the dependency on external Redis service for running tests locally
* Ensures consistent test environment that doesn't require external services

**What code technical debt it removes?**
* Removes the need for developers to run Redis locally just to run tests
* Eliminates the coupling between test environment and external infrastructure
* Improves developer experience by making tests more self-contained

# Solution

**How this PR solves the problem:**
* Configures the test environment to use Sidekiq's fake testing mode instead of requiring a real Redis connection
* Uses `Sidekiq::Testing.fake!` to queue jobs in memory during tests
* Maintains the same test behavior while removing external dependencies

**How was the bug fixed?**
* Added Sidekiq fake mode configuration to `config/environments/test.rb`
* Jobs are now queued in memory instead of Redis during tests
* Tests can verify job enqueuing without requiring Redis infrastructure

**How was the code improved?**
* Test environment is now more isolated and self-contained
* Reduced external dependencies for running tests
* Better developer experience with faster test setup

# Testing

## Setup

To test the changes locally:

1. Ensure you have the latest code from the `test/sidekiq_base` branch
2. Run `bundle install` to ensure all dependencies are installed
3. No Redis setup required - tests will run without external dependencies

## Main scenarios

### Scenario 1: Running Sidekiq job tests without Redis

**Steps to reproduce:**
1. Make sure Redis is NOT running on your local machine
2. Run the specific failing tests: `rspec spec/sidekiq/mark_cart_as_abandoned_job_spec.rb`
3. Run the full test suite: `rspec spec`

**Expected outcome:**
- All tests should pass without Redis connection errors
- Sidekiq jobs should be queued in fake mode (in memory)
- No external Redis dependency required

### Scenario 2: Verifying Sidekiq job behavior in tests

**Steps to reproduce:**
1. Run the Sidekiq job tests: `rspec spec/sidekiq/`
2. Check that job enqueuing expectations still work correctly
3. Verify that `perform_async` calls are properly mocked/stubbed

**Expected outcome:**
- Tests should verify that jobs are being enqueued correctly
- RSpec expectations on `perform_async` should work as expected
- Job behavior should be testable without actual job execution

### Other scenarios

**Scenario 3: Development environment still uses real Sidekiq**
- Verify that development and production environments still use real Redis/Sidekiq
- Check that `config/environments/development.rb` and `config/environments/production.rb` are unchanged
- Ensure only the test environment uses fake mode

**Scenario 4: CI/CD pipeline compatibility**
- Tests should run in CI environments without requiring Redis setup
- Faster test execution due to in-memory job queuing
- More reliable CI builds with fewer external dependencies

**Scenario 5: Mixed ActiveJob and Sidekiq testing**
- Verify that both ActiveJob (using `:test` adapter) and Sidekiq jobs work together in tests
- Check that the configuration doesn't interfere with other job types
- Ensure comprehensive test coverage for all job-related functionality
